### PR TITLE
Add Server Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Mod which allows you to kill all of a certain mob in 1.7.10
 
-* /killall <entity> Attempts to kill all entities whose entity id contains <entity>.
-* /hoistall <entity> Attempts to move all entitites whose entity id contains <entity> to the floor under player's Y position.
-* /hoistall <entity> Attempts to move all entitites whose entity id contains <entity> to a point on the floor under the player's position.
-* /listall \[entity\] Lists all entity types and their counts for all matching entities, or all if \[entity\] is not provided.
+
+* `/killall <entity>` Attempts to kill all entities whose entity id contains `<entity>`.
+* `/hoistall <entity>` Attempts to move all entitites whose entity id contains `<entity>` to the floor under player's Y position.
+* `/hoistall <entity>` Attempts to move all entitites whose entity id contains `<entity>` to a point on the floor under the player's position.
+* `/listall [entity]` Lists all entity types and their counts for all matching entities, or all if `[entity]` is not provided.

--- a/src/main/java/au/lyrael/killall/KillAll.java
+++ b/src/main/java/au/lyrael/killall/KillAll.java
@@ -25,7 +25,7 @@ import static au.lyrael.killall.KillAll.*;
 import static au.lyrael.killall.utility.MathUtility.asVec3;
 import static au.lyrael.killall.utility.MathUtility.scalarMultiply;
 
-@Mod(modid = MOD_ID, name = MOD_NAME, version = VERSION, acceptedMinecraftVersions = ACCEPTED_MC_VERSIONS)
+@Mod(modid = MOD_ID, name = MOD_NAME, version = VERSION, acceptedMinecraftVersions = ACCEPTED_MC_VERSIONS, acceptableRemoteVersions = "*")
 public class KillAll {
 
 	public static final String MOD_ID = "killall";

--- a/src/main/java/au/lyrael/killall/command/ListEntityCountCommand.java
+++ b/src/main/java/au/lyrael/killall/command/ListEntityCountCommand.java
@@ -53,7 +53,7 @@ public class ListEntityCountCommand implements ICommand {
 			);
 			LOGGER.info("Counting entities which match [{}]", String.join(",", args));
 
-			final List<Entity> loadedEntityList = world.getLoadedEntityList();
+			final List<Entity> loadedEntityList = world.loadedEntityList;
 			final List<EntityLiving> livingEntities = getLivingEntities(loadedEntityList);
 			final List<EntityLiving> matchingEntities = getMatchingEntities(entity -> matchByName(matchString, entity), livingEntities);
 

--- a/src/main/java/au/lyrael/killall/command/ListEntityDetailsCommand.java
+++ b/src/main/java/au/lyrael/killall/command/ListEntityDetailsCommand.java
@@ -53,7 +53,7 @@ public class ListEntityDetailsCommand implements ICommand {
 			);
 			LOGGER.info("Listing entities which match [{}]", String.join(",", args));
 
-			final List<Entity> loadedEntityList = world.getLoadedEntityList();
+			final List<Entity> loadedEntityList = world.loadedEntityList;
 			final List<EntityLiving> livingEntities = getLivingEntities(loadedEntityList);
 			final List<EntityLiving> matchingEntities = getMatchingEntities(entity -> matchByName(matchString, entity), livingEntities);
 

--- a/src/main/java/au/lyrael/killall/command/VerbAllProcessor.java
+++ b/src/main/java/au/lyrael/killall/command/VerbAllProcessor.java
@@ -27,7 +27,7 @@ public class VerbAllProcessor {
 			final String queryForLogging
 	) {
 		World world = sender.getEntityWorld();
-		final List<Entity> loadedEntityList = world.getLoadedEntityList();
+		final List<Entity> loadedEntityList = world.loadedEntityList;
 
 		final List<EntityLiving> livingEntities = EntityListUtil.getLivingEntities(loadedEntityList);
 		final List<EntityLiving> matchingEntities = EntityListUtil.getMatchingEntities(matcher, livingEntities);


### PR DESCRIPTION
Hello,

Not sure if you still care about this mod at all, but I tried to use it on a dedicated server the other day and ran into some issues which I've fixed:
- The previous version crashes when running on a server, because `world.getLoadedEntityList()` is only defined client-side, but does nothing more than just return `world.loadedEntityList` which is defined on both. Accessing that directly therefore works on servers. 🤷🏻 
- Removed the requirement for both client and server to have the mod installed. You can now install it only on the server (and use the command), or only on the client (still won't do anything on servers that don't have it)

With those resolved, I was able to use it on the server to fix an ongoing lag problem due to thousands of mod entities piling up in one area.

I additionally fixed the documentation formatting, some of the arguments were being hidden as they were interpreted as HTML tags.

Thanks!